### PR TITLE
Feature/arrow dont deserialise

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -78,25 +78,25 @@ jobs:
         path: ./test_results3.xml
     
 
-    - uses: vemonet/setup-spark@v1
-      with:
-        spark-url: https://archive.apache.org/dist/spark/spark-4.0.0-preview2/spark-4.0.0-preview2-bin-hadoop3.tgz
-        spark-version: '4.0.0-preview2'
-        hadoop-version: '3'
+    # - uses: vemonet/setup-spark@v1
+    #   with:
+    #     spark-url: https://archive.apache.org/dist/spark/spark-4.0.0-preview2/spark-4.0.0-preview2-bin-hadoop3.tgz
+    #     spark-version: '4.0.0-preview2'
+    #     hadoop-version: '3'
     
-    - run: $SPARK_HOME/sbin/stop-connect-server.sh --force
+    # - run: $SPARK_HOME/sbin/stop-connect-server.sh --force
     
-    - run: $SPARK_HOME/sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.13:4.0.0-preview2
+    # - run: $SPARK_HOME/sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.13:4.0.0-preview2
 
-    - name: Execute unit tests Spark 4.0
-      working-directory: ./src/test/Spark.Connect.Dotnet.Tests/
-      run: dotnet test -l:"console;verbosity=detailed" --logger "trx;LogFileName=./test_results4.xml" --filter "SparkMinVersion=4"
+    # - name: Execute unit tests Spark 4.0
+    #   working-directory: ./src/test/Spark.Connect.Dotnet.Tests/
+    #   run: dotnet test -l:"console;verbosity=detailed" --logger "trx;LogFileName=./test_results4.xml" --filter "SparkMinVersion=4"
 
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      with:
-        name: Test Results
-        path: ./test_results4.xml
+    # - name: Upload test results
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: Test Results
+    #     path: ./test_results4.xml
 
 
     

--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
@@ -147,7 +147,7 @@ public class SparkSession
                 try
                 {   
                     Console.WriteLine(DateTime.Now + " :: Trying Connection");
-                    Sql("SELECT 'spark-connect-dotnet' as client").Collect();
+                    Sql("SELECT 'spark-connect-dotnet' as client").CollectAsArrowBatch();
                     return;
                 }
                 catch (Exception ex)

--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/StringIsNotNullExtensions.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/StringIsNotNullExtensions.cs
@@ -1,0 +1,6 @@
+namespace Spark.Connect.Dotnet;
+
+public static class StringIsNotNullExtensions
+{
+    public static bool IsNotNullAndIsNotEmpty(this string str) => !string.IsNullOrEmpty(str);
+}

--- a/src/test/Spark.Connect.Dotnet.Tests/DataFrame/CatalogTests.cs
+++ b/src/test/Spark.Connect.Dotnet.Tests/DataFrame/CatalogTests.cs
@@ -27,7 +27,8 @@ public class CatalogTests : E2ETestBase
     public void GetDatabaseTest()
     {
         var currentDatabase = "default";
-        Spark.Catalog.GetDatabase(currentDatabase);
+        var database = Spark.Catalog.GetDatabase(currentDatabase);
+        Assert.Equal(database.name, currentDatabase);
     }
 
     [Fact]
@@ -36,12 +37,102 @@ public class CatalogTests : E2ETestBase
         Spark.Sql("CREATE OR REPLACE FUNCTION my_func1 AS 'test.org.apache.spark.sql.MyDoubleAvg'");
         var function = Spark.Catalog.GetFunction("my_func1");
         Assert.Equal("my_func1", function.name);
-        Console.WriteLine(function.ToString());
+        Assert.Equal(new[]{"default"}, function.namesSpace);
+    }
+    
+    [Fact]
+    public void ListFunctionTest()
+    {
+        Spark.Sql("CREATE OR REPLACE FUNCTION my_func1 AS 'test.org.apache.spark.sql.MyDoubleAvg'");
+        Spark.Sql("CREATE OR REPLACE FUNCTION my_func2 AS 'test.org.apache.spark.sql.MyDoubleAvg'");
+        Spark.Sql("CREATE OR REPLACE FUNCTION my_func3 AS 'test.org.apache.spark.sql.MyDoubleAvg'");
+
+        var functions = Spark.Catalog.ListFunctions();
+        Assert.Contains(functions, f => f.name == "my_func1");
+        Assert.Contains(functions, f => f.name == "my_func2");
+        Assert.Contains(functions, f => f.name == "my_func3");
+    }
+    
+    [Fact]
+    public void ListDatabasesTest()
+    {
+        
+        Spark.Sql("CREATE DATABASE IF NOT EXISTS db1");
+        Spark.Sql("CREATE DATABASE IF NOT EXISTS db2");
+        Spark.Sql("CREATE DATABASE IF NOT EXISTS db3");
+        
+        var databases = Spark.Catalog.ListDatabases();
+        Assert.Contains(databases, f => f.name == "db1");
+        Assert.Contains(databases, f => f.name == "db2");
+        Assert.Contains(databases, f => f.name == "db3");
+    }
+    
+    [Fact]
+    public void ListColumnsTest()
+    {
+        Spark.Sql("SELECT 1 as i, 2.0 as f, 'test' as str, current_timestamp() as now").Write().SaveAsTable("columns_test", null, "overwrite");
+        
+        var columns = Spark.Catalog.ListColumns("columns_test");
+        Assert.Contains(columns, f => f.name == "i");
+        Assert.Contains(columns, f => f.name == "f");
+            
+        Assert.Contains(columns, f => f.name == "now");
+    }
+    
+    [Fact]
+    public void GetTableTest()
+    {
+        Spark.Range(100).Write().SaveAsTable("my_table", "parquet", "overwrite");
+        var table = Spark.Catalog.GetTable("my_table");
+        Assert.Equal("my_table", table.name);
+        Assert.Equal(new[]{"default"}, table.nameSpace);
+    }
+
+    
+    [Fact]
+    public void ListTablesTest()
+    {
+        Spark.Range(100).Write().SaveAsTable("my_table1", "parquet", "overwrite");
+        Spark.Range(100).Write().SaveAsTable("my_table2", "parquet", "overwrite");
+        Spark.Range(100).Write().SaveAsTable("my_table3", "csv", "overwrite");
+        
+        var table = Spark.Catalog.ListTables(Spark.Catalog.CurrentDatabase());
+        
+        Assert.Contains(table, p => p.name == "my_table1");
+        Assert.Contains(table, p => p.name == "my_table2");
+        Assert.Contains(table, p => p.name == "my_table3");
+    }
+
+ 
+    
+    [Fact]
+    public void TableExistsTest()
+    {
+        Spark.Range(100).Write().SaveAsTable("my_table1", "parquet", "overwrite");
+        
+        var exists = Spark.Catalog.TableExists("my_table1");
+        Assert.True(exists);
+        
+        exists = Spark.Catalog.TableExists("IDONTEXIST");
+        Assert.False(exists);
     }
 
     [Fact]
     public void ListCatalogTest()
     {
-        Console.WriteLine(Spark.Catalog.ListCatalogs());
+        var catalogs = Spark.Catalog.ListCatalogs();
+        Assert.Contains(catalogs, f => f.name == "spark_catalog");
+    }
+
+    [Fact]
+    public void IsCachedTest()
+    {
+        var tableName = Guid.NewGuid().ToString().Replace("-", "");
+        Spark.Range(100).Write().SaveAsTable(tableName, null, "overwrite");
+        Spark.Catalog.IsCached(tableName);
+        Assert.False(Spark.Catalog.IsCached(tableName));
+        
+        Spark.Catalog.CacheTable(tableName, new StorageLevel(){ UseDisk = true});
+        Assert.True(Spark.Catalog.IsCached(tableName));
     }
 }


### PR DESCRIPTION
Apache Arrow is an optimised format for storing data in memory and the core principal is that pointers are used to read data without having to deserialize the data into .NET objects.

Instead of forcing our own parsing of the arrow data, allow the `RequestExecutor` to expose the Arrow data which can then be read using the Apache Arrow .NET library.

Callers will have a better idea of what they need to do, if they want to still use our parsing then they can call `Collect`, if they want to better handle the data (the recommended) then use `CollectAsArrow` to get the pointers to the arrow data,