### PR TITLE
Implement interrupt all on spark session

### DIFF
--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Grpc/GrpcInternal.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Grpc/GrpcInternal.cs
@@ -451,4 +451,36 @@ public static class GrpcInternal
         return items;
     }
     
+
+    public static async Task<List<string>> InterruptAll(SparkSession session)
+    {
+        var interruptRequest = new InterruptRequest
+        {
+          ClientType = session.ClientType,  SessionId = session.SessionId, UserContext = session.UserContext,
+          InterruptType = InterruptRequest.Types.InterruptType.All
+        };
+
+        AsyncUnaryCall<InterruptResponse> Exec()
+        {
+            try
+            {
+                return session.GrpcClient.InterruptAsync(interruptRequest, session.Headers);
+            }
+            catch (Exception exception)
+            {              
+                if (exception is RpcException rpcException)
+                {
+                    throw SparkExceptionFactory.GetExceptionFromRpcException(rpcException);
+                }
+
+                throw new SparkException(exception);
+            }
+        }
+
+        var response = await Exec();
+
+        return response.InterruptedIds.Select(s => s).ToList();
+        
+    }
+
 }

--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Grpc/GrpcInternal.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Grpc/GrpcInternal.cs
@@ -451,7 +451,11 @@ public static class GrpcInternal
         return items;
     }
     
-
+    /// <summary>
+    /// Interrupt all operations of this session currently running on the connected server.
+    /// </summary>
+    /// <param name="session"></param>
+    /// <exception cref="SparkException"></exception>
     public static async Task<List<string>> InterruptAll(SparkSession session)
     {
         var interruptRequest = new InterruptRequest

--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
@@ -879,6 +879,15 @@ public class SparkSession
     {
     }
 
+    public List<string> InterruptAll()
+    {
+        var task = Task.Run(()=>GrpcInternal.InterruptAll(this));
+        task.Wait();
+
+        return task.Result;
+            
+    }
+
     public string Version()
     {
         return GrpcInternal.Version(this);

--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
@@ -879,6 +879,9 @@ public class SparkSession
     {
     }
 
+    /// <summary>
+    /// Interrupt all operations of this session currently running on the connected server.
+    /// </summary>
     public List<string> InterruptAll()
     {
         var task = Task.Run(()=>GrpcInternal.InterruptAll(this));

--- a/src/test/Spark.Connect.Dotnet.Tests/SparkSession_Tests.cs
+++ b/src/test/Spark.Connect.Dotnet.Tests/SparkSession_Tests.cs
@@ -143,4 +143,10 @@ public class SparkSession_Tests : E2ETestBase
             .Select(Col("another_col"));
         Logger.WriteLine(df.Relation.ToString());
     }
+
+    [Fact]
+    public void InterruptAll_Test()
+    {
+        Spark.InterruptAll();
+    }
 }


### PR DESCRIPTION
Added code to call InterruptAll function so we can cancel long running jobs.

https://spark.apache.org/docs/4.0.0-preview2/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.interruptAll.html#pyspark.sql.SparkSession.interruptAll