### PR TITLE
Added gRPC channel connection timeout

### DIFF
--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSession.cs
@@ -75,7 +75,11 @@ public class SparkSession
             }
         });
 
-        Task.Run(() => channel.ConnectAsync()).Wait();
+        var connectTimeLimit = int.Parse(sparkConnectDotnetConf.GetValueOrDefault(SparkDotnetKnownConfigKeys.ConnectTimeLimit, 
+                SparkDotnetDefaultConfigValues.ConnectTimeLimit));
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromSeconds(connectTimeLimit));
+        channel.ConnectAsync(cts.Token).Wait();
 
         GrpcClient = new SparkConnectService.SparkConnectServiceClient(channel);
         VerifyDatabricksClusterRunning(databricksConnectionMaxVerificationTime);

--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSessionBuilder.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/Sql/SparkSessionBuilder.cs
@@ -186,6 +186,12 @@ public static class SparkDotnetKnownConfigKeys
     public const string PrintMetrics = RuntimeConf.SparkDotnetConfigKey + "showmetrics";
     public const string DontDecodeArrow = RuntimeConf.SparkDotnetConfigKey + "dontdecodearrow";
     public const string RequestExecutorCancelTimeout = RuntimeConf.SparkDotnetConfigKey + "requestretrytimelimit";
+    public const string ConnectTimeLimit = RuntimeConf.SparkDotnetConfigKey + "connecttimelimit";
+}
+
+public static class SparkDotnetDefaultConfigValues
+{
+    public const string ConnectTimeLimit = "30";
 }
 
 public class RuntimeConf


### PR DESCRIPTION
In the current implementation, the SparkSession constructor waits indefinitely if the Spark Connect service is down or the URL is invalid. I added a configurable connect timeout to prevent this situation