### PR TITLE
Add HashingTF transformer

### DIFF
--- a/docs/Implemented-ml-objects.md
+++ b/docs/Implemented-ml-objects.md
@@ -57,7 +57,7 @@ Note that the current implementation is not complete and is subject to change.
 | Transformer | org.apache.spark.ml.clustering.DistributedLDAModel                         |             |
 | Transformer | org.apache.spark.ml.feature.NGram                                          |             |
 | Transformer | org.apache.spark.ml.feature.StringIndexerModel                             |             |
-| Transformer | org.apache.spark.ml.feature.HashingTF                                      |             |
+| Transformer | org.apache.spark.ml.feature.HashingTF                                      | Yes         |
 | Transformer | org.apache.spark.ml.feature.VectorIndexerModel                             |             |
 | Transformer | org.apache.spark.ml.feature.Tokenizer                                      | Yes         |
 | Transformer | org.apache.spark.ml.feature.MinHashLSHModel                                |             |

--- a/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/ML/Feature/HashingTF.cs
+++ b/src/Spark.Connect.Dotnet/Spark.Connect.Dotnet/ML/Feature/HashingTF.cs
@@ -1,0 +1,92 @@
+using Spark.Connect.Dotnet.ML.Param;
+using Spark.Connect.Dotnet.Sql;
+
+namespace Spark.Connect.Dotnet.ML.Feature;
+
+/// <summary>
+/// HashingTF converts a sequence of terms to their term frequency vectors
+/// using the hashing trick.
+/// </summary>
+/// <param name="sparkSession">The <see cref="SparkSession"/> this transformer belongs to.</param>
+/// <param name="paramMap">Optional parameters map to initialize the transformer.</param>
+public class HashingTF(SparkSession sparkSession, ParamMap paramMap) : Transformer(sparkSession, ClassName, paramMap)
+{
+    private const string ClassName = "org.apache.spark.ml.feature.HashingTF";
+
+    private static readonly ParamMap DefaultParams = new([
+        new("numFeatures", 1 << 18),
+        new("binary", false),
+        new("inputCol", string.Empty),
+        new("outputCol", string.Empty)
+    ]);
+
+    /// <summary>
+    /// Creates a <see cref="HashingTF"/> with default parameters.
+    /// </summary>
+    /// <param name="sparkSession">Spark session instance.</param>
+    public HashingTF(SparkSession sparkSession) : this(sparkSession, DefaultParams.Clone())
+    {
+    }
+
+    /// <summary>
+    /// Creates a <see cref="HashingTF"/> with parameters supplied in a dictionary.
+    /// </summary>
+    /// <param name="sparkSession">Spark session instance.</param>
+    /// <param name="parameters">Dictionary of parameters to set.</param>
+    public HashingTF(SparkSession sparkSession, IDictionary<string, dynamic> parameters)
+        : this(sparkSession, DefaultParams.Clone().Update(parameters))
+    {
+    }
+
+    /// <summary>
+    /// Sets the input column containing sequences of terms.
+    /// </summary>
+    public void SetInputCol(string value) => ParamMap.Add("inputCol", value);
+
+    /// <summary>
+    /// Sets the output column to store term frequency vectors.
+    /// </summary>
+    public void SetOutputCol(string value) => ParamMap.Add("outputCol", value);
+
+    /// <summary>
+    /// Sets the number of features (hash buckets).
+    /// </summary>
+    public void SetNumFeatures(int value) => ParamMap.Add("numFeatures", value);
+
+    /// <summary>
+    /// If true, all non-zero counts are set to 1.0.
+    /// </summary>
+    public void SetBinary(bool value) => ParamMap.Add("binary", value);
+
+    /// <summary>
+    /// Gets the input column name.
+    /// </summary>
+    public string GetInputCol() => ParamMap.Get("inputCol").Value;
+
+    /// <summary>
+    /// Gets the output column name.
+    /// </summary>
+    public string GetOutputCol() => ParamMap.Get("outputCol").Value;
+
+    /// <summary>
+    /// Gets the number of features (hash buckets).
+    /// </summary>
+    public int GetNumFeatures() => ParamMap.Get("numFeatures").Value;
+
+    /// <summary>
+    /// Gets whether features are binary.
+    /// </summary>
+    public bool GetBinary() => ParamMap.Get("binary").Value;
+
+    /// <summary>
+    /// Load a previously saved <see cref="HashingTF"/> instance.
+    /// </summary>
+    /// <param name="path">Path on the Spark Connect server to load from.</param>
+    /// <param name="spark">The <see cref="SparkSession"/> to use.</param>
+    public static HashingTF Load(string path, SparkSession spark)
+    {
+        var mlResult = Load(path, spark, ClassName);
+        var paramMap = ParamMap.FromMLOperatorParams(mlResult.OperatorInfo.Params.Params, DefaultParams.Clone());
+        return new HashingTF(spark, paramMap);
+    }
+}

--- a/src/test/Spark.Connect.Dotnet.Tests/ML/Feature/HashingTFTests.cs
+++ b/src/test/Spark.Connect.Dotnet.Tests/ML/Feature/HashingTFTests.cs
@@ -1,0 +1,82 @@
+using System.Runtime.CompilerServices;
+using Spark.Connect.Dotnet.ML.Feature;
+using Spark.Connect.Dotnet.Sql.Types;
+using Xunit.Abstractions;
+
+namespace Spark.Connect.Dotnet.Tests.ML.Feature;
+
+public class HashingTFTests(ITestOutputHelper logger) : E2ETestBase(logger)
+{
+    [Fact]
+    [Trait("SparkMinVersion", "4")]
+    public void HashingTF_Transform_Test()
+    {
+        var data = new List<(int id, string[] words)>()
+        {
+            (0, new[] { "a", "b", "c" }),
+            (1, new[] { "d", "e", "f" })
+        };
+
+        var schema = new StructType(new[]
+        {
+            new StructField("id", new IntegerType(), false),
+            new StructField("words", new ArrayType(new StringType(), true), false)
+        });
+
+        var df = Spark.CreateDataFrame(data.Cast<ITuple>(), schema);
+
+        var hashingTf = new HashingTF(Spark);
+        hashingTf.SetInputCol("words");
+        hashingTf.SetOutputCol("features");
+        hashingTf.SetNumFeatures(10);
+        hashingTf.SetBinary(false);
+
+        var result = hashingTf.Transform(df);
+        result.Show(3, 1000);
+        result.PrintSchema();
+    }
+
+    [Fact]
+    [Trait("SparkMinVersion", "4")]
+    public void HashingTF_ReadWrite_Test()
+    {
+        var data = new List<(int id, string[] words)>()
+        {
+            (0, new[] { "a", "b" }),
+            (1, new[] { "c", "d" })
+        };
+
+        var schema = new StructType(new[]
+        {
+            new StructField("id", new IntegerType(), false),
+            new StructField("words", new ArrayType(new StringType(), true), false)
+        });
+
+        var df = Spark.CreateDataFrame(data.Cast<ITuple>(), schema);
+
+        var hashingTf = new HashingTF(Spark);
+        hashingTf.SetInputCol("words");
+        hashingTf.SetOutputCol("features");
+
+        hashingTf.Save("/tmp/transformers-hashingtf");
+        var loaded = HashingTF.Load("/tmp/transformers-hashingtf", Spark);
+        var result = loaded.Transform(df);
+        result.Show(3, 1000);
+        result.PrintSchema();
+    }
+
+    [Fact]
+    [Trait("SparkMinVersion", "4")]
+    public void HashingTF_Params_Test()
+    {
+        var hashingTf = new HashingTF(Spark);
+        hashingTf.SetInputCol("input");
+        Assert.Equal("input", hashingTf.GetInputCol());
+        hashingTf.SetOutputCol("out");
+        Assert.Equal("out", hashingTf.GetOutputCol());
+        hashingTf.SetNumFeatures(123);
+        Assert.Equal(123, hashingTf.GetNumFeatures());
+        hashingTf.SetBinary(true);
+        Assert.True(hashingTf.GetBinary());
+    }
+}


### PR DESCRIPTION
## Summary
- implement HashingTF transformer with full parameter getters/setters
- add E2E tests for HashingTF
- mark HashingTF as implemented in documentation

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843efc6742483329cdc31bf58acfa81